### PR TITLE
Use ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test PyVista Plotting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       DISPLAY: ':99.0'
       PYVISTA_OFF_SCREEN: 'True'


### PR DESCRIPTION
Following the demonstration in #1 that the repository test no longer runs, I have found that reverting to ubuntu 18.04 does work. Ideally however, this test would work with ubuntu-latest. See https://github.com/rob-luke/test-pyvista-gh-action/pull/2 for a demonstration that this works.

Does anyone know how to install a minimum set of requirements to run PyVista with ubuntu latest on GitHub Actions?